### PR TITLE
update CoC team members, remove backup members, fix 2025 references

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -58,12 +58,10 @@ event:
   coc_email: coc-reports@pycon.de
   team_members: |
     - To be announced
-    - To be announced
-    - To be announced
-    - To be announced
-  backup_team_members: |
-    - To be announced
-    - To be announced
+    - Larissa Haas
+    - Esin Secil Comak
+    - Jonathon Olson
+    - Lev Dadashev
 
 committees:
   # Committee names must match the headers in the committees.md file

--- a/docs/code-of-conduct/reporting.md
+++ b/docs/code-of-conduct/reporting.md
@@ -27,10 +27,6 @@ this account are:
 
 {{config.extra.event.team_members}}
 
-In the event of a conflict of interest, you may directly contact any of the lead incident responders:
-
-{{config.extra.event.backup_team_members}}
-
 ### Report Data
 
 When you make a report via email or phone, please include:

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,10 +1,10 @@
 ---
-title: About PyCon DE & PyData 2025
+title: About PyCon DE & PyData 2026
 hide:
   - navigation
 ---
 
-# :fontawesome-solid-book-atlas: About PyCon DE & PyData 2025
+# :fontawesome-solid-book-atlas: About PyCon DE & PyData 2026
 
 ## 🚨 This is the Public Documentation for PyCon DE & PyData 2026, not the Website!
 
@@ -17,7 +17,7 @@ In case you are looking for the conference website to attend or speak  please vi
 
 ## 🤝 A Joint Conference
 
-PyCon DE & PyData 2025 brings together Python communitie,s in a unique collaboration.
+PyCon DE & PyData 2026 brings together Python communitie,s in a unique collaboration.
 From programming, software development, and data science to machine learning and artificial intelligence to MLOps,
 Community, ethics, our conference covers a wide range of topics.
 
@@ -113,7 +113,7 @@ Website: [Pioneers Hub](https://www.pioneershub.org/en/)
 
 ---
 
-Join us in making PyCon DE & PyData 2025 an unforgettable experience for the Python community!
+Join us in making PyCon DE & PyData 2026 an unforgettable experience for the Python community!
 
 --- 
 ## A Big Thank You


### PR DESCRIPTION
- Add CoC team members: Larissa Haas, Esin Secil Comak, Jonathon Olson, Lev Dadashev
- Remove backup_team_members from config and reporting page
- Update remaining 2025 references to 2026 in docs/index.md